### PR TITLE
Depend on rest-client gem in runtime

### DIFF
--- a/lib/statusio/rb/version.rb
+++ b/lib/statusio/rb/version.rb
@@ -1,3 +1,3 @@
 class StatusioClient
-  VERSION = '0.2.0'
+  VERSION = '0.2.1'
 end

--- a/statusio-rb.gemspec
+++ b/statusio-rb.gemspec
@@ -27,4 +27,5 @@ Gem::Specification.new do |spec|
   spec.bindir = 'exe'
   spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
+  spec.add_runtime_dependency 'rest-client'
 end


### PR DESCRIPTION
All dependencies should be explicitly listed in gemspec. Otherwise, this happens:

```
/home/nowaker/.rvm/rubies/ruby-2.4.1/lib/ruby/site_ruby/2.4.0/rubygems/core_ext/kernel_require.rb:55:in `require': cannot load such file -- rest-client (LoadError)
        from /home/nowaker/.rvm/rubies/ruby-2.4.1/lib/ruby/site_ruby/2.4.0/rubygems/core_ext/kernel_require.rb:55:in `require'
        from /home/nowaker/.rvm/gems/ruby-2.4.1/gems/statusio-0.2.0/lib/statusio.rb:3:in `<top (required)>'
        from /home/nowaker/.rvm/rubies/ruby-2.4.1/lib/ruby/site_ruby/2.4.0/rubygems/core_ext/kernel_require.rb:133:in `require'
        from /home/nowaker/.rvm/rubies/ruby-2.4.1/lib/ruby/site_ruby/2.4.0/rubygems/core_ext/kernel_require.rb:133:in `rescue in require'
        from /home/nowaker/.rvm/rubies/ruby-2.4.1/lib/ruby/site_ruby/2.4.0/rubygems/core_ext/kernel_require.rb:40:in `require'
        from ./count-sla-from-status-io.rb:8:in `<main>'
```

I'll be thankful for merging this and releasing version 0.2.1 to rubygems.